### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
 	"name": "Nikschavan/revslider-search-replace",
 	"description": "WP CLI Command to Search Replace Strings in revolution slider",
+	"type": "wp-cli-package",
 	"homepage": "https://github.com/Nikschavan/revslider-search-replace",
 	"license": "MIT",
 	"require": {


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
